### PR TITLE
Modify: 로그인시 useNavigate 사용하여 페이지 이동

### DIFF
--- a/src/components/login/Login.js
+++ b/src/components/login/Login.js
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import "./login.css";
 import axios from "axios";
 import { useState } from "react";
@@ -8,6 +8,7 @@ import { LoadingSpinner } from "../styledComponents/Loading";
 import { myInfoActions } from "../store/myInfo";
 
 function Login() {
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const tokenInfo = useSelector((state) => state.authToken);
   const [username, setUsername] = useState("");
@@ -38,7 +39,7 @@ function Login() {
         dispatch(SET_TOKEN(res.data.data.accessToken));
         console.log("token: " + JSON.stringify(tokenInfo));
         dispatch(myInfoActions.updateUserNum(res.data.data.userNum));
-        window.location.href = "/";
+        navigate("/");
       })
       .catch((errStatus) => {
         setLoading(false);


### PR DESCRIPTION
로그인이 완료되면 메인페이지로 이동시 `window.location.href = '/'` 코드는 웹사이트 새로고침을 한 후 해당 경로로 가는 것이지만 `useNavigate`로 이동하면 리렌더링만 되고 새로고침을 하지않는 것을 발견하여 새로고침으로 인한 화면 전체 깜박거림없이 리렌더링만 하기 위해 `useNagivate`를 사용했습니다.